### PR TITLE
feat: configure Tailwind locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "format": "prettier --write \"src/**/*.{js,css,jsx}\""
+    "format": "prettier --write \"src/**/*.{js,css,jsx}\"",
+    "build:css": "tailwindcss -i ./src/index.css -o ./public/tailwind.css --watch"
   },
   "eslintConfig": {
     "extends": [

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
                 />
                 <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
                 <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-                <script src="https://cdn.tailwindcss.com"></script>
+                <link rel="stylesheet" href="%PUBLIC_URL%/tailwind.css" />
                 <title>Zenith Prompt</title>
               </head>
               <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-/* Importation des utilitaires Tailwind CSS */
+/* Importation locale de Tailwind CSS */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- init Tailwind config
- enable local Tailwind build
- include generated CSS in public index

## Testing
- `npm test --silent` *(fails: react-scripts not found)*