### PR TITLE
Remove unused manifest link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,6 @@
                   content="Zenith Prompt - Votre gestionnaire de prompts IA"
                 />
                 <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-                <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
                 <link rel="stylesheet" href="%PUBLIC_URL%/tailwind.css" />
                 <title>Zenith Prompt</title>
               </head>


### PR DESCRIPTION
## Summary
- remove PWA manifest link from public/index.html because there is no manifest file

## Testing
- `npm test --silent` *(fails: react-scripts not found)*