### PR TITLE
Add tailwind.css to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-error.log*
 *.sln
 *.sw?
 
+# Tailwind build output
+public/tailwind.css


### PR DESCRIPTION
## Summary
- ignore Tailwind CSS build output

## Testing
- `npm test` *(fails: react-scripts not found)*