### PR TITLE
Add prompt management components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import PromptList from './PromptList';
+import PromptForm from './PromptForm';
 
 function App() {
+  const [prompts, setPrompts] = useState(() => {
+    const saved = localStorage.getItem('prompts');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('prompts', JSON.stringify(prompts));
+  }, [prompts]);
+
+  const addPrompt = (prompt) => {
+    setPrompts((prev) => [...prev, prompt]);
+  };
+
   return (
-    <div>Hello, Zenith!</div>
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Zenith Prompts</h1>
+      <PromptForm onAdd={addPrompt} />
+      <PromptList prompts={prompts} />
+    </div>
   );
 }
 

--- a/src/PromptForm.js
+++ b/src/PromptForm.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+function PromptForm({ onAdd }) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setValue('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex space-x-2 mb-4">
+      <input
+        type="text"
+        className="flex-grow border rounded px-2 py-1"
+        placeholder="Enter a prompt"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="px-3 py-1 bg-blue-500 text-white rounded"
+      >
+        Add
+      </button>
+    </form>
+  );
+}
+
+export default PromptForm;

--- a/src/PromptList.js
+++ b/src/PromptList.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function PromptList({ prompts }) {
+  if (!prompts.length) {
+    return <p>No prompts yet.</p>;
+  }
+  return (
+    <ul className="list-disc pl-5 space-y-1">
+      {prompts.map((p, index) => (
+        <li key={index}>{p}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default PromptList;


### PR DESCRIPTION
## Summary
- add `PromptList` component to display prompts
- add `PromptForm` component to capture a new prompt
- keep prompts in `App` state and persist to `localStorage`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*