### PR TITLE
Centralized backend error handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/controllers/aiModelController.js
+++ b/backend/src/controllers/aiModelController.js
@@ -1,4 +1,5 @@
 const AIModel = require('../models/AIModel');
+const handleServerError = require('../utils/handleServerError');
 
 // @desc    Create a new AI model
 // @route   POST /api/ai-models
@@ -21,10 +22,7 @@ exports.createAIModel = async (req, res) => {
       data: aiModel
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -47,10 +45,7 @@ exports.getAIModels = async (req, res) => {
       data: aiModels
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -81,10 +76,7 @@ exports.getAIModel = async (req, res) => {
       data: aiModel
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -133,10 +125,7 @@ exports.updateAIModel = async (req, res) => {
       data: aiModel
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -177,10 +166,7 @@ exports.deleteAIModel = async (req, res) => {
       data: {}
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -231,9 +217,6 @@ exports.seedAIModels = async (req, res) => {
       message: 'System AI models seeded successfully'
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };

--- a/backend/src/controllers/projectController.js
+++ b/backend/src/controllers/projectController.js
@@ -1,4 +1,5 @@
 const Project = require('../models/Project');
+const handleServerError = require('../utils/handleServerError');
 
 // @desc    Create a new project
 // @route   POST /api/projects
@@ -20,10 +21,7 @@ exports.createProject = async (req, res) => {
       data: project
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -40,10 +38,7 @@ exports.getProjects = async (req, res) => {
       data: projects
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -74,10 +69,7 @@ exports.getProject = async (req, res) => {
       data: project
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -118,10 +110,7 @@ exports.updateProject = async (req, res) => {
       data: project
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -154,9 +143,6 @@ exports.deleteProject = async (req, res) => {
       data: {}
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };

--- a/backend/src/controllers/promptController.js
+++ b/backend/src/controllers/promptController.js
@@ -1,6 +1,7 @@
 const Prompt = require('../models/Prompt');
 const Project = require('../models/Project');
 const AIModel = require('../models/AIModel');
+const handleServerError = require('../utils/handleServerError');
 
 // @desc    Create a new prompt
 // @route   POST /api/prompts
@@ -53,10 +54,7 @@ exports.createPrompt = async (req, res) => {
       data: prompt
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -107,10 +105,7 @@ exports.getPrompts = async (req, res) => {
       data: prompts
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -143,10 +138,7 @@ exports.getPrompt = async (req, res) => {
       data: prompt
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -218,10 +210,7 @@ exports.updatePrompt = async (req, res) => {
       data: prompt
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -254,10 +243,7 @@ exports.deletePrompt = async (req, res) => {
       data: {}
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -291,9 +277,6 @@ exports.usePrompt = async (req, res) => {
       data: prompt
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,5 +1,6 @@
 const User = require('../models/User');
 const jwt = require('jsonwebtoken');
+const handleServerError = require('../utils/handleServerError');
 
 // Helper function to generate JWT token
 const generateToken = (id) => {
@@ -45,10 +46,7 @@ exports.registerUser = async (req, res) => {
       }
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -100,10 +98,7 @@ exports.loginUser = async (req, res) => {
       }
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };
 
@@ -124,9 +119,6 @@ exports.getUserProfile = async (req, res) => {
       }
     });
   } catch (error) {
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    handleServerError(res, error);
   }
 };

--- a/backend/src/utils/handleServerError.js
+++ b/backend/src/utils/handleServerError.js
@@ -1,0 +1,7 @@
+module.exports = (res, error) => {
+  console.error(error);
+  res.status(500).json({
+    success: false,
+    error: error.message
+  });
+};


### PR DESCRIPTION
## Summary
- add shared `handleServerError` helper
- use it across backend controllers
- fix backend start scripts to point to `server.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0af87b50832aafeaf8d48fbc458a