### PR TITLE
Improve auth error messages

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -87,6 +87,11 @@ export const AuthProvider = ({ children }) => {
       if (err.response && err.response.data.error) {
         // If the server provides an error message, use it
         setError(err.response.data.error);
+      } else if (err.response) {
+        // Response received without a specific error message
+        const status = err.response.status;
+        setError(`Registration failed${status ? ` (status ${status})` : ''}. Please try again.`);
+        console.error('Registration error status:', status);
       } else if (err.message === 'Network Error') {
         // Handle network errors
         setError('Unable to connect to the server. Please check your internet connection and try again.');
@@ -122,6 +127,11 @@ export const AuthProvider = ({ children }) => {
       if (err.response && err.response.data.error) {
         // If the server provides an error message, use it
         setError(err.response.data.error);
+      } else if (err.response) {
+        // Response received without a specific error message
+        const status = err.response.status;
+        setError(`Login failed${status ? ` (status ${status})` : ''}. Please try again.`);
+        console.error('Login error status:', status);
       } else if (err.message === 'Network Error') {
         // Handle network errors
         setError('Unable to connect to the server. Please check your internet connection and try again.');


### PR DESCRIPTION
## Summary
- handle missing server `error` field when registering or logging in
- log status codes for easier debugging

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f15804f78832abbf7c6b3067606c9